### PR TITLE
Add kstream-take procedure and unit tests for it

### DIFF
--- a/stream/stream.rkt
+++ b/stream/stream.rkt
@@ -20,5 +20,13 @@
   (if (= i 0)
     (kstream-head s)
     (kstream-nth (kstream-tail s) (- i 1))))
-  
-(provide kstream kstream-head kstream-tail kstream-nth)
+
+(define (kstream-take s n)
+  (cond
+   [(<= n 0) '()]
+   [(null? (kstream-tail s)) (list (kstream-head s))]
+   [else (cons (kstream-head s)
+               (kstream-take (kstream-tail s)
+                             (- n 1)))]))
+
+(provide kstream kstream-head kstream-tail kstream-nth kstream-take)

--- a/stream/stream_test.rkt
+++ b/stream/stream_test.rkt
@@ -30,3 +30,20 @@
      (check-equal? (kstream-nth s index) index)
      (check-equal? count index)
      )))
+
+(test-case
+ "taking n elements of a stream using kstream-take"
+ (define (zeros)
+   (kstream 0 zeros))
+ (define finite-stream
+   (kstream 1
+            (lambda ()
+              (kstream 2
+                       (lambda ()
+                         (kstream 3
+                                  (lambda () '())))))))
+ (let ([z (zeros)])
+  (check-equal? (kstream-take z 0) '())
+  (check-equal? (length (kstream-take z 3)) 3)
+  (check-equal? (kstream-take z 3) '(0 0 0))
+  (check-equal? (kstream-take finite-stream 10) '(1 2 3))))


### PR DESCRIPTION
*kstream-take* receives as parameter a *kstream* and a integer *n*
to take elements from this stream. The final result is a conventional
racket list constructed by reading the stream *n* times.

If a stream is finite and has only *k* elements, the procedure returns a list
of *min(n, k)* elements.

A set of unit tests covering the basic usage is provided.

Usage:

```racket
> (require "prime.rkt" "numbers.rkt" "stream.rkt")
> (kstream-take (naturals) 10)
'(1 2 3 4 5 6 7 8 9 10)
> (kstream-take (primes-stream) 10)
'(2 3 5 7 11 13 17 19 23 29)
```